### PR TITLE
used Reduce to simplify in invW method

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -5,3 +5,4 @@ DiffEqBase
 DiffRules
 SpecialFunctions
 NaNMath
+Reduce

--- a/REQUIRE
+++ b/REQUIRE
@@ -6,3 +6,4 @@ DiffRules
 SpecialFunctions
 NaNMath
 Reduce
+Requires

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -2,15 +2,18 @@ module ModelingToolkit
 
 using DiffEqBase
 using StaticArrays
-using Reduce
+using Requires
 
 import MacroTools: splitdef, combinedef
 import IterTools: product
-import Reduce: RExpr
 
-Algebra.operator(:\,:inv,:identity)
-Algebra.rlet(:(identity(~x))=>:x)
-Algebra.rlet(:(inv(~x))=>:(x^(-1)))
+@require Reduce begin
+    using Reduce
+    import Reduce: RExpr
+    Algebra.operator(:\,:inv,:identity)
+    Algebra.rlet(:(identity(~x))=>:x)
+    Algebra.rlet(:(inv(~x))=>:(x^(-1)))
+end
 
 abstract type Expression <: Number end
 abstract type AbstractOperation <: Expression end

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -2,9 +2,15 @@ module ModelingToolkit
 
 using DiffEqBase
 using StaticArrays
+using Reduce
 
 import MacroTools: splitdef, combinedef
 import IterTools: product
+import Reduce: RExpr
+
+Algebra.operator(:\,:inv,:identity)
+Algebra.rlet(:(identity(~x))=>:x)
+Algebra.rlet(:(inv(~x))=>:(x^(-1)))
 
 abstract type Expression <: Number end
 abstract type AbstractOperation <: Expression end

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -19,6 +19,10 @@ function Base.Expr(O::Operation)
     Expr(:call, Symbol(O.op), Expr.(O.args)...)
 end
 
+function Reduce.RExpr(O::Operation)
+    RExpr(Expr(O))
+end
+
 Base.show(io::IO,O::Operation) = print(io,string(Expr(O)))
 
 # Bigger printing

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -19,8 +19,10 @@ function Base.Expr(O::Operation)
     Expr(:call, Symbol(O.op), Expr.(O.args)...)
 end
 
-function Reduce.RExpr(O::Operation)
-    RExpr(Expr(O))
+@require Reduce begin
+    function Reduce.RExpr(O::Operation)
+        RExpr(Expr(O))
+    end
 end
 
 Base.show(io::IO,O::Operation) = print(io,string(Expr(O)))

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -6,7 +6,10 @@ Differential(x) = Differential(x,1)
 
 Base.show(io::IO, D::Differential) = print(io,"($(D.x),$(D.order))")
 Base.Expr(D::Differential) = :($(Symbol("D_$(D.x.name)_$(D.order)")))
-Reduce.RExpr(D::Differential) = RExpr(Expr(D))
+
+@require Reduce begin
+    Reduce.RExpr(D::Differential) = RExpr(Expr(D))
+end
 
 function Derivative end
 Base.:*(D::Differential,x::Operation) = Operation(Derivative,Expression[x,D])

--- a/src/operators.jl
+++ b/src/operators.jl
@@ -6,6 +6,7 @@ Differential(x) = Differential(x,1)
 
 Base.show(io::IO, D::Differential) = print(io,"($(D.x),$(D.order))")
 Base.Expr(D::Differential) = :($(Symbol("D_$(D.x.name)_$(D.order)")))
+Reduce.RExpr(D::Differential) = RExpr(Expr(D))
 
 function Derivative end
 Base.:*(D::Differential,x::Operation) = Operation(Derivative,Expression[x,D])

--- a/src/systems/diffeqs/diffeqsystem.jl
+++ b/src/systems/diffeqs/diffeqsystem.jl
@@ -103,21 +103,26 @@ function generate_ode_iW(sys::DiffEqSystem,simplify=true)
     iW = inv(W)
 
     if simplify
-        iW = simplify_constants.(iW)
+        #iW = simplify_constants.(iW)
+        iW = horner.(Expr.(iW))
     end
 
-    W = inv(I/gam - jac)
-    W = SMatrix{size(W,1),size(W,2)}(W)
-    iW_t = inv(W)
+    W = I/gam - jac
+    #W = SMatrix{size(W,1),size(W,2)}(W)
+    #iW_t = inv(W)
+    iW_t = Algebra.inv(Expr.(W))
     if simplify
-        iW_t = simplify_constants.(iW_t)
+        #iW_t = simplify_constants.(iW_t)
+        iW_t = horner.(iW_t)
     end
 
-    iW_exprs = [:(iW[$i,$j] = $(Expr(iW[i,j]))) for i in 1:size(iW,1), j in 1:size(iW,2)]
+    #iW_exprs = [:(iW[$i,$j] = $(Expr(iW[i,j]))) for i in 1:size(iW,1), j in 1:size(iW,2)]
+    iW_exprs = [:(iW[$i,$j] = $(iW[i,j])) for i in 1:size(iW,1), j in 1:size(iW,2)]
     exprs = vcat(var_exprs,param_exprs,vec(iW_exprs))
     block = expr_arr_to_block(exprs)
 
-    iW_t_exprs = [:(iW[$i,$j] = $(Expr(iW_t[i,j]))) for i in 1:size(iW_t,1), j in 1:size(iW_t,2)]
+    #iW_t_exprs = [:(iW[$i,$j] = $(Expr(iW_t[i,j]))) for i in 1:size(iW_t,1), j in 1:size(iW_t,2)]
+    iW_t_exprs = [:(iW[$i,$j] = $(iW_t[i,j])) for i in 1:size(iW_t,1), j in 1:size(iW_t,2)]
     exprs = vcat(var_exprs,param_exprs,vec(iW_t_exprs))
     block2 = expr_arr_to_block(exprs)
     :((iW,u,p,gam,t)->$(block)),:((iW,u,p,gam,t)->$(block2))

--- a/src/systems/diffeqs/diffeqsystem.jl
+++ b/src/systems/diffeqs/diffeqsystem.jl
@@ -95,34 +95,37 @@ function generate_ode_iW(sys::DiffEqSystem,simplify=true)
     diff_idxs = map(eq->eq.args[1].diff !=nothing,sys.eqs)
     diff_exprs = sys.eqs[diff_idxs]
     jac = sys.jac
-
     gam = Variable(:gam)
-
     W = I - gam*jac
-    W = SMatrix{size(W,1),size(W,2)}(W)
-    iW = inv(W)
-
-    if simplify
-        #iW = simplify_constants.(iW)
-        iW = horner.(Expr.(iW))
+    iW = if Requires.loaded(:Reduce)
+        horner.(Algebra.inv(Expr.(W)))
+    else
+        W = SMatrix{size(W,1),size(W,2)}(W)
+        inv(W)
+        simplify ? simplify_constants.(inv(W)) : inv(W)
     end
-
+    
     W = I/gam - jac
-    #W = SMatrix{size(W,1),size(W,2)}(W)
-    #iW_t = inv(W)
-    iW_t = Algebra.inv(Expr.(W))
-    if simplify
-        #iW_t = simplify_constants.(iW_t)
-        iW_t = horner.(iW_t)
+    iW_t = if Requires.loaded(:Reduce)
+        horner.(Algebra.inv(Expr.(W)))
+    else
+        W = SMatrix{size(W,1),size(W,2)}(W)
+        simplify ? simplify_constants.(inv(W)) : inv(W)
     end
 
-    #iW_exprs = [:(iW[$i,$j] = $(Expr(iW[i,j]))) for i in 1:size(iW,1), j in 1:size(iW,2)]
-    iW_exprs = [:(iW[$i,$j] = $(iW[i,j])) for i in 1:size(iW,1), j in 1:size(iW,2)]
+    iW_exprs = if Requires.loaded(:Reduce)
+        [:(iW[$i,$j] = $(iW[i,j])) for i in 1:size(iW,1), j in 1:size(iW,2)]
+    else
+        [:(iW[$i,$j] = $(Expr(iW[i,j]))) for i in 1:size(iW,1), j in 1:size(iW,2)]
+    end
     exprs = vcat(var_exprs,param_exprs,vec(iW_exprs))
     block = expr_arr_to_block(exprs)
 
-    #iW_t_exprs = [:(iW[$i,$j] = $(Expr(iW_t[i,j]))) for i in 1:size(iW_t,1), j in 1:size(iW_t,2)]
-    iW_t_exprs = [:(iW[$i,$j] = $(iW_t[i,j])) for i in 1:size(iW_t,1), j in 1:size(iW_t,2)]
+    iW_t_exprs = if Requires.loaded(:Reduce)
+        [:(iW[$i,$j] = $(iW_t[i,j])) for i in 1:size(iW_t,1), j in 1:size(iW_t,2)]
+    else
+        [:(iW[$i,$j] = $(Expr(iW_t[i,j]))) for i in 1:size(iW_t,1), j in 1:size(iW_t,2)]
+    end
     exprs = vcat(var_exprs,param_exprs,vec(iW_t_exprs))
     block2 = expr_arr_to_block(exprs)
     :((iW,u,p,gam,t)->$(block)),:((iW,u,p,gam,t)->$(block2))

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -87,8 +87,10 @@ function Base.Expr(x::Variable)
     end
 end
 
-function Reduce.RExpr(x::Variable)
-    return RExpr(Expr(x))
+@require Reduce begin
+    function Reduce.RExpr(x::Variable)
+        return RExpr(Expr(x))
+    end
 end
 
 function Base.show(io::IO, A::Variable)

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -87,6 +87,10 @@ function Base.Expr(x::Variable)
     end
 end
 
+function Reduce.RExpr(x::Variable)
+    return RExpr(Expr(x))
+end
+
 function Base.show(io::IO, A::Variable)
     if A.subtype == :Constant
         print(io,"Constant($(A.value))")


### PR DESCRIPTION
this pull-request demonstrates how `Reduce` can be used to get a 3x performance boost by using it for expression simplification instead of the `symplify_constants` method.