### PR TITLE
improved invW and calculate_jacobian

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,4 +6,5 @@ DiffRules
 SpecialFunctions
 NaNMath
 Reduce
+ReduceLinAlg
 Requires

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -9,7 +9,9 @@ import IterTools: product
 
 @require Reduce begin
     using Reduce
+    using ReduceLinAlg
     import Reduce: RExpr
+    Reduce.Rational(false)
     Algebra.operator(:\,:inv,:identity)
     Algebra.rlet(:(identity(~x))=>:x)
     Algebra.rlet(:(inv(~x))=>:(x^(-1)))


### PR DESCRIPTION
This pull-request introduces a new method called `expr2mk` which helps with converting an `Expr` back into a `ModelingToolkit.Operation` by assigning all the variables from `DiffEqSystem` and evaluating them.

This is then used along with `mat_jacobian` from `ReduceLinAlg` package to calculate the jacobian when the `Reduce` package is also loaded. With the `expr2mk` method this can be safely fed back into the original `DiffEqSystem` in the required format.