### PR TITLE
Remove `include("connections.jl")`

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -29,7 +29,6 @@ include("systems/diffeqs/diffeqsystem.jl")
 include("systems/diffeqs/first_order_transform.jl")
 include("systems/nonlinear/nonlinear_system.jl")
 include("function_registration.jl")
-include("connections.jl")
 include("simplify.jl")
 include("utils.jl")
 


### PR DESCRIPTION
Fixes

```julia
julia> using ModelingToolkit
[ Info: Precompiling ModelingToolkit [b80ccba4-6cf6-52c1-9130-c30a91c08b6c]
WARNING: Method definition Derivative(typeof(Base.atan), Any, Type{Base.Val{1}}) in module ModelingToolkit at /home/scheme/.julia/dev/ModelingToolkit/src/operators.jl:62 overwritten at /home/scheme/.julia/dev/ModelingToolkit/src/operators.jl:52.
ERROR: LoadError: could not open file /home/scheme/.julia/dev/ModelingToolkit/src/connections.jl
Stacktrace:
 [1] include at ./boot.jl:317 [inlined]
 [2] include_relative(::Module, ::String) at ./loading.jl:1041
...
```