### PR TITLE
Refactor :DependentVariable into :Unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to manipulate.
 ### Example: ODE
 
 Let's build an ODE. First we define some variables. In a differential equation
-system, we need to differentiate between our dependent variables, independent
+system, we need to differentiate between our unknown variables, independent
 variables, and parameters. Therefore we label them as follows:
 
 ```julia
@@ -29,7 +29,7 @@ using ModelingToolkit
 
 # Define some variables
 @IVar t
-@DVar x(t) y(t) z(t)
+@Unknown x(t) y(t) z(t)
 @Deriv D'~t
 @Param σ ρ β
 ```
@@ -87,12 +87,12 @@ f = ODEFunction(de)
 
 We can also build nonlinear systems. Let's say we wanted to solve for the steady
 state of the previous ODE. This is the nonlinear system defined by where the
-derivatives are zero. We could use dependent variables for our nonlinear system
+derivatives are zero. We could use unknown variables for our nonlinear system
 (for direct compatibility with the above ODE code), or we can use non-tagged
 variables. Here we will show the latter. We write:
 
 ```julia
-@DVar x y z
+@Unknown x y z
 @Param σ ρ β
 
 # Define a nonlinear system
@@ -191,7 +191,7 @@ structure is as follows:
   the system of equations.
 - Name to subtype mappings: these describe how variable `subtype`s are mapped
   to the contexts of the system. For example, for a differential equation,
-  the dependent variable corresponds to given subtypes and then the `eqs` can
+  the unknown variable corresponds to given subtypes and then the `eqs` can
   be analyzed knowing what the state variables are.
 - Variable names which do not fall into one of the system's core subtypes are
   treated as intermediates which can be used for holding subcalculations and
@@ -262,7 +262,7 @@ syntactic sugar in some form. For example, the variable construction:
 
 ```julia
 @IVar t
-@DVar x(t) y(t) z(t)
+@Unknown x(t) y(t) z(t)
 @Deriv D'~t
 @Param σ ρ β
 ```
@@ -271,9 +271,9 @@ is syntactic sugar for:
 
 ```julia
 t = IndependentVariable(:t)
-x = DependentVariable(:x,dependents = [t])
-y = DependentVariable(:y,dependents = [t])
-z = DependentVariable(:z,dependents = [t])
+x = Unknown(:x, dependents = [t])
+y = Unknown(:y, dependents = [t])
+z = Unknown(:z, dependents = [t])
 D = Differential(t) # Default of first derivative, Derivative(t,1)
 σ = Parameter(:σ)
 ρ = Parameter(:ρ)
@@ -285,7 +285,7 @@ D = Differential(t) # Default of first derivative, Derivative(t,1)
 The system building functions can handle intermediate calculations. For example,
 
 ```julia
-@DVar a x y z
+@Unknown a x y z
 @Param σ ρ β
 eqs = [a ~ y-x,
        0 ~ σ*a,

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Each operation builds an `Operation` type, and thus `eqs` is an array of
 analyzed by other programs. We can turn this into a `DiffEqSystem` via:
 
 ```julia
-de = DiffEqSystem(eqs,[t],[x,y,z],Variable[],[σ,ρ,β])
+de = DiffEqSystem(eqs,[t],[x,y,z],[σ,ρ,β])
 de = DiffEqSystem(eqs)
 ```
 
@@ -285,10 +285,10 @@ D = Differential(t) # Default of first derivative, Derivative(t,1)
 The system building functions can handle intermediate calculations. For example,
 
 ```julia
-@Unknown a x y z
+@Unknown x y z
 @Param σ ρ β
-eqs = [a ~ y-x,
-       0 ~ σ*a,
+a = y - x
+eqs = [0 ~ σ*a,
        0 ~ x*(ρ-z)-y,
        0 ~ x*y - β*z]
 ns = NonlinearSystem(eqs,[x,y,z],[σ,ρ,β])

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ derivatives are zero. We could use dependent variables for our nonlinear system
 variables. Here we will show the latter. We write:
 
 ```julia
-@Var x y z
+@DVar x y z
 @Param σ ρ β
 
 # Define a nonlinear system
@@ -285,7 +285,7 @@ D = Differential(t) # Default of first derivative, Derivative(t,1)
 The system building functions can handle intermediate calculations. For example,
 
 ```julia
-@Var a x y z
+@DVar a x y z
 @Param σ ρ β
 eqs = [a ~ y-x,
        0 ~ σ*a,

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ to manipulate.
 ### Example: ODE
 
 Let's build an ODE. First we define some variables. In a differential equation
-system, we need to differentiate between our unknown variables, independent
+system, we need to differentiate between our unknown (dependent) variables, independent
 variables, and parameters. Therefore we label them as follows:
 
 ```julia
@@ -87,9 +87,7 @@ f = ODEFunction(de)
 
 We can also build nonlinear systems. Let's say we wanted to solve for the steady
 state of the previous ODE. This is the nonlinear system defined by where the
-derivatives are zero. We could use unknown variables for our nonlinear system
-(for direct compatibility with the above ODE code), or we can use non-tagged
-variables. Here we will show the latter. We write:
+derivatives are zero. We use unknown variables for our nonlinear system.
 
 ```julia
 @Unknown x y z

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -33,9 +33,14 @@ function vars!(vars, op)
     args = isa(op, Equation) ? Expression[op.lhs, op.rhs] : op.args
 
     for arg ∈ args
-        isa(arg, Operation) ? vars!(vars, arg) :
-        isa(arg, Variable)  ? push!(vars, arg) :
-        nothing
+        if isa(arg, Operation)
+            vars!(vars, arg)
+        elseif isa(arg, Variable)
+            push!(vars, arg)
+            for dep ∈ arg.dependents
+                push!(vars, dep)
+            end
+        end
     end
 
     return vars

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -13,7 +13,7 @@ Base.:~(lhs::Number    , rhs::Expression) = Equation(lhs, rhs)
 
 
 _is_derivative(x::Variable) = x.diff !== nothing
-_is_dependent(x::Variable) = x.subtype === :DependentVariable && !isempty(x.dependents)
+_is_dependent(x::Variable) = x.subtype === :Unknown && !isempty(x.dependents)
 _subtype(subtype::Symbol) = x -> x.subtype === subtype
 
 function extract_elements(eqs, predicates)

--- a/src/equations.jl
+++ b/src/equations.jl
@@ -12,40 +12,31 @@ Base.:~(lhs::Expression, rhs::Number    ) = Equation(lhs, rhs)
 Base.:~(lhs::Number    , rhs::Expression) = Equation(lhs, rhs)
 
 
-function extract_elements(eqs, targetmap, default = nothing)
-    elems = Dict{Symbol, Vector{Variable}}()
-    names = Dict{Symbol, Set{Symbol}}()
-    if default == nothing
-        targets =  unique(collect(values(targetmap)))
-    else
-        targets = [unique(collect(values(targetmap))), default]
-    end
-    for target in targets
-        elems[target] = Vector{Variable}()
-        names[target] = Set{Symbol}()
-    end
-    for eq in eqs
-        extract_elements!(eq, elems, names, targetmap, default)
-    end
-    Tuple(elems[target] for target in targets)
-end
-# Walk the tree recursively and push variables into the right set
-function extract_elements!(op, elems, names, targetmap, default)
-    args = isa(op, Equation) ? Expression[op.lhs, op.rhs] : op.args
+_is_derivative(x::Variable) = x.diff !== nothing
+_is_dependent(x::Variable) = x.subtype === :DependentVariable && !isempty(x.dependents)
+_subtype(subtype::Symbol) = x -> x.subtype === subtype
 
-    for arg in args
-        if arg isa Operation
-            extract_elements!(arg, elems, names, targetmap, default)
-        elseif arg isa Variable
-            if default == nothing
-                target = haskey(targetmap, arg.subtype) ? targetmap[arg.subtype] : continue
-            else
-                target = haskey(targetmap, arg.subtype) ? targetmap[arg.subtype] : default
-            end
-            if !in(arg.name, names[target])
-                push!(names[target], arg.name)
-                push!(elems[target], arg)
-            end
+function extract_elements(eqs, predicates)
+    result = [Variable[] for p ∈ predicates]
+    vars = foldl(vars!, eqs; init=Set{Variable}())
+
+    for var ∈ vars
+        for (i, p) ∈ enumerate(predicates)
+            p(var) && (push!(result[i], var); break)
         end
     end
+
+    return result
+end
+
+function vars!(vars, op)
+    args = isa(op, Equation) ? Expression[op.lhs, op.rhs] : op.args
+
+    for arg ∈ args
+        isa(arg, Operation) ? vars!(vars, arg) :
+        isa(arg, Variable)  ? push!(vars, arg) :
+        nothing
+    end
+
+    return vars
 end

--- a/src/systems/diffeqs/diffeqsystem.jl
+++ b/src/systems/diffeqs/diffeqsystem.jl
@@ -18,7 +18,7 @@ function DiffEqSystem(eqs, ivs, dvs, vs, ps)
 end
 
 function DiffEqSystem(eqs; iv_name = :IndependentVariable,
-                           dv_name = :DependentVariable,
+                           dv_name = :Unknown,
                            p_name = :Parameter)
     predicates = [_is_derivative, _subtype(iv_name), _is_dependent, _subtype(dv_name), _subtype(p_name)]
     _, ivs, dvs, vs, ps = extract_elements(eqs, predicates)
@@ -26,7 +26,7 @@ function DiffEqSystem(eqs; iv_name = :IndependentVariable,
 end
 
 function DiffEqSystem(eqs, ivs;
-                      dv_name = :DependentVariable,
+                      dv_name = :Unknown,
                       p_name = :Parameter)
     predicates = [_is_derivative, _is_dependent, _subtype(dv_name), _subtype(p_name)]
     _, dvs, vs, ps = extract_elements(eqs, predicates)
@@ -98,7 +98,7 @@ function generate_ode_iW(sys::DiffEqSystem, simplify=true)
     diff_exprs = filter(!isintermediate, sys.eqs)
     jac = sys.jac
 
-    gam = DependentVariable(:gam)
+    gam = Unknown(:gam)
 
     W = LinearAlgebra.I - gam*jac
     W = SMatrix{size(W,1),size(W,2)}(W)

--- a/src/systems/diffeqs/diffeqsystem.jl
+++ b/src/systems/diffeqs/diffeqsystem.jl
@@ -2,23 +2,22 @@ mutable struct DiffEqSystem <: AbstractSystem
     eqs::Vector{Equation}
     ivs::Vector{Variable}
     dvs::Vector{Variable}
-    vs::Vector{Variable}
     ps::Vector{Variable}
     jac::Matrix{Expression}
 end
 
-DiffEqSystem(eqs, ivs, dvs, vs, ps) = DiffEqSystem(eqs, ivs, dvs, vs, ps, Matrix{Expression}(undef,0,0))
+DiffEqSystem(eqs, ivs, dvs, ps) = DiffEqSystem(eqs, ivs, dvs, ps, Matrix{Expression}(undef,0,0))
 
 function DiffEqSystem(eqs)
-    predicates = [_is_derivative, _subtype(:IndependentVariable), _is_dependent, _subtype(:Unknown), _subtype(:Parameter)]
-    _, ivs, dvs, vs, ps = extract_elements(eqs, predicates)
-    DiffEqSystem(eqs, ivs, dvs, vs, ps, Matrix{Expression}(undef,0,0))
+    predicates = [_is_derivative, _subtype(:IndependentVariable), _is_dependent, _subtype(:Parameter)]
+    _, ivs, dvs, ps = extract_elements(eqs, predicates)
+    DiffEqSystem(eqs, ivs, dvs, ps, Matrix{Expression}(undef,0,0))
 end
 
 function DiffEqSystem(eqs, ivs)
-    predicates = [_is_derivative, _is_dependent, _subtype(:Unknown), _subtype(:Parameter)]
-    _, dvs, vs, ps = extract_elements(eqs, predicates)
-    DiffEqSystem(eqs, ivs, dvs, vs, ps, Matrix{Expression}(undef,0,0))
+    predicates = [_is_derivative, _is_dependent, _subtype(:Parameter)]
+    _, dvs, ps = extract_elements(eqs, predicates)
+    DiffEqSystem(eqs, ivs, dvs, ps, Matrix{Expression}(undef,0,0))
 end
 
 function generate_ode_function(sys::DiffEqSystem;version = ArrayFunction)

--- a/src/systems/diffeqs/diffeqsystem.jl
+++ b/src/systems/diffeqs/diffeqsystem.jl
@@ -4,33 +4,21 @@ mutable struct DiffEqSystem <: AbstractSystem
     dvs::Vector{Variable}
     vs::Vector{Variable}
     ps::Vector{Variable}
-    iv_name::Symbol
-    dv_name::Symbol
-    p_name::Symbol
     jac::Matrix{Expression}
 end
 
-function DiffEqSystem(eqs, ivs, dvs, vs, ps)
-    iv_name = ivs[1].subtype
-    dv_name = dvs[1].subtype
-    p_name = isempty(ps) ? :Parameter : ps[1].subtype
-    DiffEqSystem(eqs, ivs, dvs, vs, ps, iv_name, dv_name, p_name, Matrix{Expression}(undef,0,0))
-end
+DiffEqSystem(eqs, ivs, dvs, vs, ps) = DiffEqSystem(eqs, ivs, dvs, vs, ps, Matrix{Expression}(undef,0,0))
 
-function DiffEqSystem(eqs; iv_name = :IndependentVariable,
-                           dv_name = :Unknown,
-                           p_name = :Parameter)
-    predicates = [_is_derivative, _subtype(iv_name), _is_dependent, _subtype(dv_name), _subtype(p_name)]
+function DiffEqSystem(eqs)
+    predicates = [_is_derivative, _subtype(:IndependentVariable), _is_dependent, _subtype(:Unknown), _subtype(:Parameter)]
     _, ivs, dvs, vs, ps = extract_elements(eqs, predicates)
-    DiffEqSystem(eqs, ivs, dvs, vs, ps, iv_name, dv_name, p_name, Matrix{Expression}(undef,0,0))
+    DiffEqSystem(eqs, ivs, dvs, vs, ps, Matrix{Expression}(undef,0,0))
 end
 
-function DiffEqSystem(eqs, ivs;
-                      dv_name = :Unknown,
-                      p_name = :Parameter)
-    predicates = [_is_derivative, _is_dependent, _subtype(dv_name), _subtype(p_name)]
+function DiffEqSystem(eqs, ivs)
+    predicates = [_is_derivative, _is_dependent, _subtype(:Unknown), _subtype(:Parameter)]
     _, dvs, vs, ps = extract_elements(eqs, predicates)
-    DiffEqSystem(eqs, ivs, dvs, vs, ps, ivs[1].subtype, dv_name, p_name, Matrix{Expression}(undef,0,0))
+    DiffEqSystem(eqs, ivs, dvs, vs, ps, Matrix{Expression}(undef,0,0))
 end
 
 function generate_ode_function(sys::DiffEqSystem;version = ArrayFunction)

--- a/src/systems/diffeqs/diffeqsystem.jl
+++ b/src/systems/diffeqs/diffeqsystem.jl
@@ -19,34 +19,31 @@ end
 
 function DiffEqSystem(eqs; iv_name = :IndependentVariable,
                            dv_name = :DependentVariable,
-                           v_name = :Variable,
                            p_name = :Parameter)
-    targetmap =  Dict(iv_name => iv_name, dv_name => dv_name, v_name => v_name,
-                       p_name => p_name)
-    ivs, dvs, vs, ps = extract_elements(eqs, targetmap)
-    DiffEqSystem(eqs, ivs, dvs, vs, ps, iv_name, dv_name, p_name, Matrix{Expression}(0,0))
+    predicates = [_is_derivative, _subtype(iv_name), _is_dependent, _subtype(dv_name), _subtype(p_name)]
+    _, ivs, dvs, vs, ps = extract_elements(eqs, predicates)
+    DiffEqSystem(eqs, ivs, dvs, vs, ps, iv_name, dv_name, p_name, Matrix{Expression}(undef,0,0))
 end
 
 function DiffEqSystem(eqs, ivs;
                       dv_name = :DependentVariable,
-                      v_name = :Variable,
                       p_name = :Parameter)
-    targetmap =  Dict(dv_name => dv_name, v_name => v_name, p_name => p_name)
-    dvs, vs, ps = extract_elements(eqs, targetmap)
+    predicates = [_is_derivative, _is_dependent, _subtype(dv_name), _subtype(p_name)]
+    _, dvs, vs, ps = extract_elements(eqs, predicates)
     DiffEqSystem(eqs, ivs, dvs, vs, ps, ivs[1].subtype, dv_name, p_name, Matrix{Expression}(undef,0,0))
 end
 
 function generate_ode_function(sys::DiffEqSystem;version = ArrayFunction)
-    var_exprs = [:($(sys.dvs[i].name) = u[$i]) for i in 1:length(sys.dvs)]
-    param_exprs = [:($(sys.ps[i].name) = p[$i]) for i in 1:length(sys.ps)]
+    var_exprs = [:($(sys.dvs[i].name) = u[$i]) for i in eachindex(sys.dvs)]
+    param_exprs = [:($(sys.ps[i].name) = p[$i]) for i in eachindex(sys.ps)]
     sys_exprs = build_equals_expr.(sys.eqs)
     if version == ArrayFunction
-        dvar_exprs = [:(du[$i] = $(Symbol("$(sys.dvs[i].name)_$(sys.ivs[1].name)"))) for i in 1:length(sys.dvs)]
+        dvar_exprs = [:(du[$i] = $(Symbol("$(sys.dvs[i].name)_$(sys.ivs[1].name)"))) for i in eachindex(sys.dvs)]
         exprs = vcat(var_exprs,param_exprs,sys_exprs,dvar_exprs)
         block = expr_arr_to_block(exprs)
         :((du,u,p,t)->$(toexpr(block)))
     elseif version == SArrayFunction
-        dvar_exprs = [:($(Symbol("$(sys.dvs[i].name)_$(sys.ivs[1].name)"))) for i in 1:length(sys.dvs)]
+        dvar_exprs = [:($(Symbol("$(sys.dvs[i].name)_$(sys.ivs[1].name)"))) for i in eachindex(sys.dvs)]
         svector_expr = quote
             E = eltype(tuple($(dvar_exprs...)))
             T = StaticArrays.similar_type(typeof(u), E)
@@ -84,8 +81,8 @@ function calculate_jacobian(sys::DiffEqSystem, simplify=true)
 end
 
 function generate_ode_jacobian(sys::DiffEqSystem, simplify=true)
-    var_exprs = [:($(sys.dvs[i].name) = u[$i]) for i in 1:length(sys.dvs)]
-    param_exprs = [:($(sys.ps[i].name) = p[$i]) for i in 1:length(sys.ps)]
+    var_exprs = [:($(sys.dvs[i].name) = u[$i]) for i in eachindex(sys.dvs)]
+    param_exprs = [:($(sys.ps[i].name) = p[$i]) for i in eachindex(sys.ps)]
     diff_exprs = filter(!isintermediate, sys.eqs)
     jac = calculate_jacobian(sys, simplify)
     sys.jac = jac
@@ -96,8 +93,8 @@ function generate_ode_jacobian(sys::DiffEqSystem, simplify=true)
 end
 
 function generate_ode_iW(sys::DiffEqSystem, simplify=true)
-    var_exprs = [:($(sys.dvs[i].name) = u[$i]) for i in 1:length(sys.dvs)]
-    param_exprs = [:($(sys.ps[i].name) = p[$i]) for i in 1:length(sys.ps)]
+    var_exprs = [:($(sys.dvs[i].name) = u[$i]) for i in eachindex(sys.dvs)]
+    param_exprs = [:($(sys.ps[i].name) = p[$i]) for i in eachindex(sys.ps)]
     diff_exprs = filter(!isintermediate, sys.eqs)
     jac = sys.jac
 

--- a/src/systems/diffeqs/diffeqsystem.jl
+++ b/src/systems/diffeqs/diffeqsystem.jl
@@ -101,7 +101,7 @@ function generate_ode_iW(sys::DiffEqSystem, simplify=true)
     diff_exprs = filter(!isintermediate, sys.eqs)
     jac = sys.jac
 
-    gam = Variable(:gam)
+    gam = DependentVariable(:gam)
 
     W = LinearAlgebra.I - gam*jac
     W = SMatrix{size(W,1),size(W,2)}(W)

--- a/src/systems/nonlinear/nonlinear_system.jl
+++ b/src/systems/nonlinear/nonlinear_system.jl
@@ -2,21 +2,11 @@ struct NonlinearSystem <: AbstractSystem
     eqs::Vector{Equation}
     vs::Vector{Variable}
     ps::Vector{Variable}
-    v_name::Vector{Symbol}
-    p_name::Symbol
 end
 
-function NonlinearSystem(eqs, vs, ps;
-                         v_name = :Unknown,
-                         p_name = :Parameter)
-    NonlinearSystem(eqs, vs, ps, [v_name], p_name)
-end
-
-function NonlinearSystem(eqs;
-                         v_name = :Unknown,
-                         p_name = :Parameter)
-    vs, ps = extract_elements(eqs, [_subtype(v_name), _subtype(p_name)])
-    NonlinearSystem(eqs, vs, ps, [v_name], p_name)
+function NonlinearSystem(eqs)
+    vs, ps = extract_elements(eqs, [_subtype(:Unknown), _subtype(:Parameter)])
+    NonlinearSystem(eqs, vs, ps)
 end
 
 function generate_nlsys_function(sys::NonlinearSystem)

--- a/src/systems/nonlinear/nonlinear_system.jl
+++ b/src/systems/nonlinear/nonlinear_system.jl
@@ -7,20 +7,17 @@ struct NonlinearSystem <: AbstractSystem
 end
 
 function NonlinearSystem(eqs, vs, ps;
-                         v_name = :Variable,
-                         dv_name = :DependentVariable,
+                         v_name = :DependentVariable,
                          p_name = :Parameter)
-    NonlinearSystem(eqs, vs, ps, [v_name,dv_name], p_name)
+    NonlinearSystem(eqs, vs, ps, [v_name], p_name)
 end
 
 function NonlinearSystem(eqs;
-                         v_name = :Variable,
-                         dv_name = :DependentVariable,
+                         v_name = :DependentVariable,
                          p_name = :Parameter)
-    # Allow the use of :DependentVariable to make it seamless with DE use
-    targetmap = Dict(v_name => v_name, dv_name => v_name, p_name => p_name)
+    targetmap = Dict(v_name => v_name, p_name => p_name)
     vs, ps = extract_elements(eqs, targetmap)
-    NonlinearSystem(eqs, vs, ps, [v_name,dv_name], p_name)
+    NonlinearSystem(eqs, vs, ps, [v_name], p_name)
 end
 
 function generate_nlsys_function(sys::NonlinearSystem)

--- a/src/systems/nonlinear/nonlinear_system.jl
+++ b/src/systems/nonlinear/nonlinear_system.jl
@@ -7,13 +7,13 @@ struct NonlinearSystem <: AbstractSystem
 end
 
 function NonlinearSystem(eqs, vs, ps;
-                         v_name = :DependentVariable,
+                         v_name = :Unknown,
                          p_name = :Parameter)
     NonlinearSystem(eqs, vs, ps, [v_name], p_name)
 end
 
 function NonlinearSystem(eqs;
-                         v_name = :DependentVariable,
+                         v_name = :Unknown,
                          p_name = :Parameter)
     vs, ps = extract_elements(eqs, [_subtype(v_name), _subtype(p_name)])
     NonlinearSystem(eqs, vs, ps, [v_name], p_name)

--- a/src/systems/nonlinear/nonlinear_system.jl
+++ b/src/systems/nonlinear/nonlinear_system.jl
@@ -15,8 +15,7 @@ end
 function NonlinearSystem(eqs;
                          v_name = :DependentVariable,
                          p_name = :Parameter)
-    targetmap = Dict(v_name => v_name, p_name => p_name)
-    vs, ps = extract_elements(eqs, targetmap)
+    vs, ps = extract_elements(eqs, [_subtype(v_name), _subtype(p_name)])
     NonlinearSystem(eqs, vs, ps, [v_name], p_name)
 end
 

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -11,11 +11,7 @@ Variable(name, args...; kwargs...) = Variable(name, args...; subtype=:Variable, 
 
 Parameter(name,args...;kwargs...) = Variable(name,args...;subtype=:Parameter,kwargs...)
 IndependentVariable(name,args...;kwargs...) = Variable(name,args...;subtype=:IndependentVariable,kwargs...)
-
-function DependentVariable(name,args...;dependents = [],kwargs...)
-    @assert !isempty(dependents)
-    Variable(name,args...;subtype=:DependentVariable,dependents=dependents,kwargs...)
-end
+DependentVariable(name,args...;kwargs...) = Variable(name,args...;subtype=:DependentVariable,kwargs...)
 
 export Variable,Parameter,Constant,DependentVariable,IndependentVariable,
        @Var, @Param, @Const, @DVar, @IVar

--- a/src/variables.jl
+++ b/src/variables.jl
@@ -10,10 +10,10 @@ Variable(name; subtype::Symbol, dependents::Vector{Variable} = Variable[]) =
 
 Parameter(name,args...;kwargs...) = Variable(name,args...;subtype=:Parameter,kwargs...)
 IndependentVariable(name,args...;kwargs...) = Variable(name,args...;subtype=:IndependentVariable,kwargs...)
-DependentVariable(name,args...;kwargs...) = Variable(name,args...;subtype=:DependentVariable,kwargs...)
+Unknown(name,args...;kwargs...) = Variable(name,args...;subtype=:Unknown,kwargs...)
 
-export Variable,Parameter,Constant,DependentVariable,IndependentVariable,
-       @Param, @Const, @DVar, @IVar
+export Variable,Parameter,Constant,Unknown,IndependentVariable,
+       @Param, @Const, @Unknown, @IVar
 
 
 Base.copy(x::Variable) = Variable(x.name, x.subtype, x.diff, x.dependents)
@@ -83,7 +83,7 @@ function _parse_vars(macroname, fun, x)
     return ex
 end
 
-for funs in [(:DVar, :DependentVariable), (:IVar, :IndependentVariable), (:Param, :Parameter)]
+for funs in [(:Unknown, :Unknown), (:IVar, :IndependentVariable), (:Param, :Parameter)]
     @eval begin
         macro ($(funs[1]))(x...)
             esc(_parse_vars(String($funs[1]), $funs[2], x))

--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -2,7 +2,7 @@ using ModelingToolkit
 using Test
 
 @IVar t
-@DVar x(t) y(t) z(t)
+@Unknown x(t) y(t) z(t)
 
 struct __MyType__ end
 Base.:~(::__MyType__,::Number) = 2

--- a/test/basic_variables_and_operations.jl
+++ b/test/basic_variables_and_operations.jl
@@ -3,7 +3,6 @@ using Test
 
 @IVar t
 @DVar x(t) y(t) z(t)
-@test_throws AssertionError @DVar w
 
 @Deriv D'~t # Default of first derivative, Derivative(t,1)
 @Param σ ρ β

--- a/test/basic_variables_and_operations.jl
+++ b/test/basic_variables_and_operations.jl
@@ -2,7 +2,7 @@ using ModelingToolkit
 using Test
 
 @IVar t
-@DVar x(t) y(t) z(t)
+@Unknown x(t) y(t) z(t)
 
 @Deriv D'~t # Default of first derivative, Derivative(t,1)
 @Param σ ρ β
@@ -10,7 +10,7 @@ using Test
 
 # Default values
 p = Parameter(:p)
-u = DependentVariable(:u, dependents = [t])
+u = Unknown(:u, dependents = [t])
 
 σ*(y-x)
 D(x)

--- a/test/components.jl
+++ b/test/components.jl
@@ -17,7 +17,7 @@ function generate_lorenz_eqs(t,x,y,z,σ,ρ,β)
      D(z) ~ x*y - β*z]
 end
 function Lorenz(t)
-    @DVar x(t) y(t) z(t)
+    @Unknown x(t) y(t) z(t)
     @Param σ ρ β
     Lorenz(x, y, z, σ, ρ, β, generate_lorenz_eqs(t, x, y, z, σ, ρ, β))
 end

--- a/test/derivatives.jl
+++ b/test/derivatives.jl
@@ -3,7 +3,7 @@ using Test
 
 # Derivatives
 @IVar t
-@Var x(t) y(t) z(t)
+@DVar x(t) y(t) z(t)
 @Param σ ρ β
 @Deriv D'~t
 dsin = D(sin(t))
@@ -43,5 +43,5 @@ jac = ModelingToolkit.calculate_jacobian(sys)
 @test jac[3,3] == -1*β
 
 # Variable dependence checking in differentiation
-@Var a(t) b(a)
+@DVar a(t) b(a)
 @test D(b) ≠ Constant(0)

--- a/test/derivatives.jl
+++ b/test/derivatives.jl
@@ -3,7 +3,7 @@ using Test
 
 # Derivatives
 @IVar t
-@DVar x(t) y(t) z(t)
+@Unknown x(t) y(t) z(t)
 @Param σ ρ β
 @Deriv D'~t
 dsin = D(sin(t))
@@ -43,5 +43,5 @@ jac = ModelingToolkit.calculate_jacobian(sys)
 @test jac[3,3] == -1*β
 
 # Variable dependence checking in differentiation
-@DVar a(t) b(a)
+@Unknown a(t) b(a)
 @test D(b) ≠ Constant(0)

--- a/test/internal.jl
+++ b/test/internal.jl
@@ -4,7 +4,7 @@ using Test
 # `Expr`, `Number` -> `Operation`
 @IVar a
 @Param b
-@DVar x(t) y()
+@Unknown x(t) y()
 @test convert(Expression, 2) == 2
 expr = :(-inv(2sqrt(+($a, $b))))
 op   = Operation(-, [Operation(inv,

--- a/test/internal.jl
+++ b/test/internal.jl
@@ -4,8 +4,7 @@ using Test
 # `Expr`, `Number` -> `Operation`
 @IVar a
 @Param b
-@DVar x(t)
-@Var y
+@DVar x(t) y()
 @test convert(Expression, 2) == 2
 expr = :(-inv(2sqrt(+($a, $b))))
 op   = Operation(-, [Operation(inv,

--- a/test/simplify.jl
+++ b/test/simplify.jl
@@ -2,7 +2,7 @@ using ModelingToolkit
 using Test
 
 @IVar t
-@DVar x(t) y(t) z(t)
+@Unknown x(t) y(t) z(t)
 
 null_op = 0*t
 @test simplify_constants(null_op) == Constant(0)

--- a/test/system_construction.jl
+++ b/test/system_construction.jl
@@ -91,8 +91,8 @@ eqs = [_x ~ y/C,
        D(x) ~ -A*x,
        D(y) ~ A*x - B*_x]
 de = DiffEqSystem(eqs,[t],[x,y],Variable[_x],[A,B,C])
-de2 = DiffEqSystem(eqs,[t])
-test_vars_extraction(de, de2)
+test_vars_extraction(de, DiffEqSystem(eqs,[t]))
+test_vars_extraction(de, DiffEqSystem(eqs))
 @test eval(ModelingToolkit.generate_ode_function(de))([0.0,0.0],[1.0,2.0],[1,2,3],0.0) ≈ -1/3
 
 # Now nonlinear system with only variables

--- a/test/system_construction.jl
+++ b/test/system_construction.jl
@@ -3,7 +3,7 @@ using Test
 
 # Define some variables
 @IVar t
-@Unknown x(t) y(t) z(t) a()
+@Unknown x(t) y(t) z(t)
 @Deriv D'~t # Default of first derivative, Derivative(t,1)
 @Param σ ρ β
 @Const c=0
@@ -12,7 +12,7 @@ using Test
 eqs = [D(x) ~ σ*(y-x),
        D(y) ~ x*(ρ-z)-y,
        D(z) ~ x*y - β*z]
-de = DiffEqSystem(eqs,[t],[x,y,z],Variable[],[σ,ρ,β])
+de = DiffEqSystem(eqs,[t],[x,y,z],[σ,ρ,β])
 ModelingToolkit.generate_ode_function(de)
 ModelingToolkit.generate_ode_function(de;version=ModelingToolkit.SArrayFunction)
 jac_expr = ModelingToolkit.generate_ode_jacobian(de)
@@ -24,7 +24,7 @@ ModelingToolkit.generate_ode_iW(de)
 de2 = DiffEqSystem(eqs, [t])
 
 function test_vars_extraction(de, de2)
-    for el in (:ivs, :dvs, :vs, :ps)
+    for el in (:ivs, :dvs, :ps)
         names2 = sort(collect(var.name for var in getfield(de2,el)))
         names = sort(collect(var.name for var in getfield(de,el)))
         @test names2 == names
@@ -61,11 +61,11 @@ end
 @test_broken test_eqs(de1.eqs, lowered_eqs)
 
 # Internal calculations
-eqs = [a ~ y-x,
-       D(x) ~ σ*a,
+a = y - x
+eqs = [D(x) ~ σ*a,
        D(y) ~ x*(ρ-z)-y,
        D(z) ~ x*y - β*z]
-de = DiffEqSystem(eqs,[t],[x,y,z],[a],[σ,ρ,β])
+de = DiffEqSystem(eqs,[t],[x,y,z],[σ,ρ,β])
 ModelingToolkit.generate_ode_function(de)
 jac = ModelingToolkit.calculate_jacobian(de)
 f = ODEFunction(de)
@@ -84,13 +84,12 @@ end
 
 ModelingToolkit.generate_nlsys_function(ns)
 
-@Unknown _x
 @Deriv D'~t
 @Param A B C
-eqs = [_x ~ y/C,
-       D(x) ~ -A*x,
+_x = y / C
+eqs = [D(x) ~ -A*x,
        D(y) ~ A*x - B*_x]
-de = DiffEqSystem(eqs,[t],[x,y],Variable[_x],[A,B,C])
+de = DiffEqSystem(eqs,[t],[x,y],[A,B,C])
 test_vars_extraction(de, DiffEqSystem(eqs,[t]))
 test_vars_extraction(de, DiffEqSystem(eqs))
 @test eval(ModelingToolkit.generate_ode_function(de))([0.0,0.0],[1.0,2.0],[1,2,3],0.0) ≈ -1/3

--- a/test/system_construction.jl
+++ b/test/system_construction.jl
@@ -3,11 +3,10 @@ using Test
 
 # Define some variables
 @IVar t
-@DVar x(t) y(t) z(t)
+@DVar x(t) y(t) z(t) a()
 @Deriv D'~t # Default of first derivative, Derivative(t,1)
 @Param σ ρ β
 @Const c=0
-@Var a
 
 # Define a differential equation
 eqs = [D(x) ~ σ*(y-x),
@@ -85,7 +84,7 @@ end
 
 ModelingToolkit.generate_nlsys_function(ns)
 
-@Var _x
+@DVar _x
 @Deriv D'~t
 @Param A B C
 eqs = [_x ~ y/C,
@@ -95,7 +94,7 @@ de = DiffEqSystem(eqs,[t],[x,y],Variable[_x],[A,B,C])
 @test eval(ModelingToolkit.generate_ode_function(de))([0.0,0.0],[1.0,2.0],[1,2,3],0.0) ≈ -1/3
 
 # Now nonlinear system with only variables
-@Var x y z
+@DVar x y z
 @Param σ ρ β
 
 # Define a nonlinear system

--- a/test/system_construction.jl
+++ b/test/system_construction.jl
@@ -20,7 +20,7 @@ jac = ModelingToolkit.calculate_jacobian(de)
 f = ODEFunction(de)
 ModelingToolkit.generate_ode_iW(de)
 
-# Differential equation with automatic extraction of variables on rhs
+# Differential equation with automatic extraction of variables
 de2 = DiffEqSystem(eqs, [t])
 
 function test_vars_extraction(de, de2)

--- a/test/system_construction.jl
+++ b/test/system_construction.jl
@@ -91,6 +91,8 @@ eqs = [_x ~ y/C,
        D(x) ~ -A*x,
        D(y) ~ A*x - B*_x]
 de = DiffEqSystem(eqs,[t],[x,y],Variable[_x],[A,B,C])
+de2 = DiffEqSystem(eqs,[t])
+test_vars_extraction(de, de2)
 @test eval(ModelingToolkit.generate_ode_function(de))([0.0,0.0],[1.0,2.0],[1,2,3],0.0) ≈ -1/3
 
 # Now nonlinear system with only variables

--- a/test/system_construction.jl
+++ b/test/system_construction.jl
@@ -3,7 +3,7 @@ using Test
 
 # Define some variables
 @IVar t
-@DVar x(t) y(t) z(t) a()
+@Unknown x(t) y(t) z(t) a()
 @Deriv D'~t # Default of first derivative, Derivative(t,1)
 @Param σ ρ β
 @Const c=0
@@ -35,7 +35,7 @@ test_vars_extraction(de, de2)
 # Conversion to first-order ODEs #17
 @Deriv D3'''~t
 @Deriv D2''~t
-@DVar u(t) u_tt(t) u_t(t) x_t(t)
+@Unknown u(t) u_tt(t) u_t(t) x_t(t)
 eqs = [D3(u) ~ 2(D2(u)) + D(u) + D(x) + 1
        D2(x) ~ D(x) + 2]
 de = DiffEqSystem(eqs, [t])
@@ -84,7 +84,7 @@ end
 
 ModelingToolkit.generate_nlsys_function(ns)
 
-@DVar _x
+@Unknown _x
 @Deriv D'~t
 @Param A B C
 eqs = [_x ~ y/C,
@@ -96,7 +96,7 @@ test_vars_extraction(de, de2)
 @test eval(ModelingToolkit.generate_ode_function(de))([0.0,0.0],[1.0,2.0],[1,2,3],0.0) ≈ -1/3
 
 # Now nonlinear system with only variables
-@DVar x y z
+@Unknown x y z
 @Param σ ρ β
 
 # Define a nonlinear system

--- a/test/variable_parsing.jl
+++ b/test/variable_parsing.jl
@@ -2,12 +2,12 @@ using ModelingToolkit
 using Test
 
 @IVar t
-@DVar x(t)
-@DVar y(t)
-@DVar z(t)
-x1 = DependentVariable(:x ,dependents = [t])
-y1 = DependentVariable(:y ,dependents = [t])
-z1 = DependentVariable(:z ,dependents = [t])
+@Unknown x(t)
+@Unknown y(t)
+@Unknown z(t)
+x1 = Unknown(:x ,dependents = [t])
+y1 = Unknown(:y ,dependents = [t])
+z1 = Unknown(:z ,dependents = [t])
 @test x1 == x
 @test y1 == y
 @test z1 == z

--- a/test/variable_parsing.jl
+++ b/test/variable_parsing.jl
@@ -1,16 +1,6 @@
 using ModelingToolkit
 using Test
 
-@Var a b
-a1 = Variable(:a)
-@test a1 == a
-@test convert(Expr, a) == :a
-
-@Var begin
-    a
-    b
-end
-
 @IVar t
 @DVar x(t)
 @DVar y(t)


### PR DESCRIPTION
Rethinks `DependentVariable` as a generic unknown function (subtype `:Unknown`).

Note that zero-argument `Unknown`s are legal, representing an unknown function with zero arguments (e.g. `x()` in `x() ~ 2x() - σ`). This is commonly written without the explicit function call notation: `@Unknown x` (equivalent to `@Unknown x()`). These are used, for example, in the representation of nonlinear systems.

In the process, the `:Variable` subtype was removed. Existing `@Var` variables (e.g. `@Var a; a ~ y-x`) are replaced with standard Julia variables (`a = y-x`) or zero-argument `@Unknown`s.