### PR TITLE
Prototype mt_setup

### DIFF
--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -3,7 +3,7 @@ module ModelingToolkit
 export Operation, Expression
 export calculate_jacobian, generate_jacobian, generate_function
 export independent_variables, dependent_variables, parameters
-export @register
+export @register, @mt_setup
 
 
 using DiffEqBase
@@ -39,5 +39,6 @@ include("systems/nonlinear/nonlinear_system.jl")
 include("function_registration.jl")
 include("simplify.jl")
 include("utils.jl")
+include("mt_setup.jl")
 
 end # module

--- a/src/mt_setup.jl
+++ b/src/mt_setup.jl
@@ -1,0 +1,6 @@
+macro mt_setup(expr)
+    MacroTools.postwalk(expr) do x
+        x == :ODEFunction ? :generate_function : x
+    end
+    expr
+end

--- a/test/mt_setup.jl
+++ b/test/mt_setup.jl
@@ -1,0 +1,19 @@
+using ModelingToolkit
+using Test
+
+f = @mt_setup begin
+    @parameters t σ ρ β
+    @variables x(t) y(t) z(t)
+    @derivatives D'~t
+
+    eqs = [D(x) ~ σ*(y-x),
+           D(y) ~ x*(ρ-z)-y,
+           D(z) ~ x*y - β*z]
+    de = ODESystem(eqs)
+    ODEFunction(de, [x,y,z], [σ,ρ,β])
+end
+
+du = zeros(3)
+u  = collect(1:3)
+p  = collect(4:6)
+f(du, u, p, 0.1)

--- a/test/mt_setup.jl
+++ b/test/mt_setup.jl
@@ -17,3 +17,4 @@ du = zeros(3)
 u  = collect(1:3)
 p  = collect(4:6)
 f(du, u, p, 0.1)
+@test du == [4, 0, -16]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,3 +4,4 @@ using ModelingToolkit, Test
 @testset "Differentiation Test" begin include("derivatives.jl") end
 @testset "Simplify Test" begin include("simplify.jl") end
 @testset "System Construction Test" begin include("system_construction.jl") end
+@testset "mt_setup Test" begin include("mt_setup.jl") end


### PR DESCRIPTION
All of ModelingToolkit was made just as standard Julia functions and types. This is nice because then it's very interactive, but sometimes you want to do something at compile time. This idea is a simple macro `@mt_setup` which replaces things (thing) that eval with the piece that generates the code. In the macro form, this then is transformed at compile time to just be a code generating macro from MT syntax.

To really make this useful, we'll want to make it so that way more than 1 function is allowed. For example, generate the ODE function and its Jacobian, and then build the ODEFunction (or ODEProblem). Maybe we could have a bit more DSL to it, but I kind of like that you can copy-paste what worked in the global scope and now stick it in a function with this. That's not true without the macro because of the evals.