### PR TITLE
Add easy possibility to create array of variables

### DIFF
--- a/test/variable_parsing.jl
+++ b/test/variable_parsing.jl
@@ -34,3 +34,25 @@ D1 = Differential(t)
 @test @macroexpand(@variables x, y, z(t)) == @macroexpand(@variables x y z(t))
 
 convert(Expression, :($x == 0 ? $y : $x))
+
+# Test array expressions
+@parameters begin
+    t[1:2]
+    s[1:2:4,1:2]
+end
+@parameters σ[1:2](..)
+
+t1 = [Variable(:t, 1; known = true)(),
+      Variable(:t, 2; known = true)()]
+s1 = [Variable(:s, 1, 1; known = true)() Variable(:s, 1, 2; known = true)()
+      Variable(:s, 3, 1; known = true)() Variable(:s, 3, 2; known = true)()]
+σ1 = [Variable(:σ, 1; known = true),
+      Variable(:σ, 2; known = true)]
+@test isequal(t1, t)
+@test isequal(s1, s)
+@test isequal(σ1, σ)
+
+@parameters t
+@variables x[1:2](t)
+x1 = [Variable(:x, 1)(t), Variable(:x, 2)(t)]
+@test isequal(x1, x)


### PR DESCRIPTION
This extends the variable / parameter generation macro to allow easy creation of arrays of variables. Closes #102.

**Examples:**
```julia
julia> @variables x[1:3];
julia> x
3-element Array{Operation,1}:
 x[1]()
 x[2]()
 x[3]()

# support for arbitrary ranges and tensors

julia> @variables y[1:3,1:5:10,1:4];

julia> y
3×2×4 Array{Operation,3}:
[:, :, 1] =
 y[1,1,1]()  y[1,6,1]()
 y[2,1,1]()  y[2,6,1]()
 y[3,1,1]()  y[3,6,1]()

[:, :, 2] =
 y[1,1,2]()  y[1,6,2]()
 y[2,1,2]()  y[2,6,2]()
 y[3,1,2]()  y[3,6,2]()

[:, :, 3] =
 y[1,1,3]()  y[1,6,3]()
 y[2,1,3]()  y[2,6,3]()
 y[3,1,3]()  y[3,6,3]()

[:, :, 4] =
 y[1,1,4]()  y[1,6,4]()
 y[2,1,4]()  y[2,6,4]()
 y[3,1,4]()  y[3,6,4]()

# also works for dependent variables
julia> @parameters t; @variables z[1:3](t);
julia> z
3-element Array{Operation,1}:
 z[1](t())
 z[2](t())
 z[3](t())
```

If the design is accepted, I will add some documentation to the readme :)

ToDo:
- [x] Documentation