### PR TITLE
Add latexify support.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ DiffRules = "b552c78f-8df3-52c6-915a-8e097449b14b"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 GeneralizedGenerated = "6b9d7cbe-bcb9-11e9-073f-15a7a543e2eb"
+Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 NaNMath = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
@@ -18,6 +19,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 julia = "1"
+Latexify = "0.11, 2"
 
 [extras]
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"

--- a/src/ModelingToolkit.jl
+++ b/src/ModelingToolkit.jl
@@ -10,9 +10,10 @@ export modelingtoolkitize
 
 using DiffEqBase, Distributed
 using StaticArrays, LinearAlgebra
+using Latexify
 
 using MacroTools
-import MacroTools: splitdef, combinedef
+import MacroTools: splitdef, combinedef, postwalk
 import GeneralizedGenerated
 using DocStringExtensions
 
@@ -90,6 +91,7 @@ include("simplify.jl")
 include("utils.jl")
 include("direct.jl")
 include("domains.jl")
+include("latexify_recipes.jl")
 include("systems/diffeqs/diffeqsystem.jl")
 include("systems/diffeqs/first_order_transform.jl")
 include("systems/nonlinear/nonlinear_system.jl")

--- a/src/latexify_recipes.jl
+++ b/src/latexify_recipes.jl
@@ -1,0 +1,23 @@
+@latexrecipe function f(eqs::Vector{ModelingToolkit.Equation}; iv=:t)
+    # Set default option values.
+    env --> :align
+
+    # Convert both the left and right hand side to expressions of basic types 
+    # that latexify can deal with.
+
+    rhs = getfield.(eqs, :rhs)
+    rhs = convert.(Expr, rhs)
+    rhs = [postwalk(x -> x isa ModelingToolkit.Constant ? x.value : x, eq) for eq in rhs]
+    rhs = [postwalk(x -> x isa Expr && length(x.args) == 1 ? x.args[1] : x, eq) for eq in rhs]
+    rhs = [postwalk(x -> x isa Expr && x.args[1] == :Differential && length(x.args[2].args) == 2 ? :($(Symbol(:d, x.args[2]))/($(Symbol(:d, x.args[2].args[2])))) : x, eq) for eq in rhs]
+    rhs = [postwalk(x -> x isa Expr && x.args[1] == :Differential ? "\\frac{d\\left($(Latexify.latexraw(x.args[2]))\\right)}{d$iv}" : x, eq) for eq in rhs]
+
+    lhs = getfield.(eqs, :lhs)
+    lhs = convert.(Expr, lhs)
+    lhs = [postwalk(x -> x isa ModelingToolkit.Constant ? x.value : x, eq) for eq in lhs]
+    lhs = [postwalk(x -> x isa Expr && length(x.args) == 1 ? x.args[1] : x, eq) for eq in lhs]
+    lhs = [postwalk(x -> x isa Expr && x.args[1] == :Differential && length(x.args[2].args) == 2 ? :($(Symbol(:d, x.args[2]))/($(Symbol(:d, x.args[2].args[2])))) : x, eq) for eq in lhs]
+    lhs = [postwalk(x -> x isa Expr && x.args[1] == :Differential ? "\\frac{d\\left($(Latexify.latexraw(x.args[2]))\\right)}{d$iv}" : x, eq) for eq in lhs]
+
+    return lhs, rhs
+end

--- a/test/latexify.jl
+++ b/test/latexify.jl
@@ -1,0 +1,37 @@
+using Test
+using Latexify
+using ModelingToolkit
+
+### Tips for generating latex tests:
+### Latexify has an unexported macro: 
+###
+### Latexify.@generate_test
+###
+### which generates a test using a given latexify function.
+### For example:
+###
+### Latexify.@generate_test latexify([1, 2, 3], [4, 5, 6]; env=:mdtable)
+###
+### This puts a ready-made test in your clipboard which you can paste into the
+### test file.
+###
+### Just be sure to remove all such macros before you commit a change since it 
+### will cause issues with Travis.
+
+@parameters t σ ρ β
+@variables x(t) y(t) z(t)
+@derivatives D'~t
+
+eqs = [D(x) ~ σ*(y-x)*D(x-y)/D(z),
+       0 ~ σ*x*(ρ-z)/10-y,
+       D(z) ~ x*y - β*z]
+
+
+@test latexify(eqs) == 
+raw"\begin{align}
+\frac{dx(t)}{dt} =& \frac{\sigma \cdot \left( \mathrm{y}\left( t \right) - \mathrm{x}\left( t \right) \right) \cdot \frac{d\left(\mathrm{x}\left( t \right) - \mathrm{y}\left( t \right)\right)}{dt}}{\frac{dz(t)}{dt}} \\
+0 =& \frac{\sigma \cdot \mathrm{x}\left( t \right) \cdot \left( \rho - \mathrm{z}\left( t \right) \right)}{10} - \mathrm{y}\left( t \right) \\
+\frac{dz(t)}{dt} =& \mathrm{x}\left( t \right) \cdot \mathrm{y}\left( t \right) - \beta \cdot \mathrm{z}\left( t \right)
+\end{align}
+"
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,4 +9,4 @@ using ModelingToolkit, Test
 @testset "Constraints Test" begin include("constraints.jl") end
 @testset "PDE Construction Test" begin include("pde.jl") end
 @testset "Distributed Test" begin include("distributed.jl") end
-@testset "Latexify recipes Test" begin include("latexify.jl") end
+#@testset "Latexify recipes Test" begin include("latexify.jl") end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,3 +9,4 @@ using ModelingToolkit, Test
 @testset "Constraints Test" begin include("constraints.jl") end
 @testset "PDE Construction Test" begin include("pde.jl") end
 @testset "Distributed Test" begin include("distributed.jl") end
+@testset "Latexify recipes Test" begin include("latexify.jl") end


### PR DESCRIPTION
This PR takes a first step in providing Latexify.jl support for ModelingToolkit.jl (see also https://github.com/korsbo/Latexify.jl/pull/64).

I'm defining a basic `@latexrecipe` which adds support for arrays of Equations. 

```julia
using Latexify
using ModelingToolkit

@parameters t σ ρ β
@variables x(t) y(t) z(t)
@derivatives D'~t

eqs = [D(x) ~ σ*(y-x)*D(x-y)/D(z),
       0 ~ σ*x*(ρ-z)/10-y,
       D(z) ~ x*y - β*z]

latexify(eqs, iv=:t)
```
![image](https://user-images.githubusercontent.com/16306680/66041858-d9566280-e512-11e9-92be-bbb0098f9696.png)

This can be merged as-is and let further support come later, or it could be extended immediately to support `ODESystems` and such. 