### PR TITLE
handle the static array cases in build_function for non-vector outputs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ModelingToolkit"
 uuid = "961ee093-0014-501f-94e3-6117800e7a78"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.2.4"
+version = "1.2.5"
 
 [deps]
 DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -33,6 +33,8 @@ function flatten_expr!(x)
     x
 end
 
+default_tensor_constructor(x) = x->(out = similar(typeof(u),$(size(rhss)...)); out .= x)
+
 function build_function(rhss, vs, ps = (), args = (), conv = simplified_expr, expression = Val{true};
                         checkbounds = false, constructor=nothing, linenumbers = true)
     _vs = map(x-> x isa Operation ? x.op : x, vs)
@@ -59,11 +61,11 @@ function build_function(rhss, vs, ps = (), args = (), conv = simplified_expr, ex
     if rhss isa Matrix
         arr_sys_expr = build_expr(:vcat, [build_expr(:row,[conv(rhs) for rhs ∈ rhss[i,:]]) for i in 1:size(rhss,1)])
         # : x because ??? what to do in the general case?
-        _constructor = constructor === nothing ? :(u isa ModelingToolkit.StaticArrays.StaticArray ? ModelingToolkit.StaticArrays.SMatrix{$(size(rhss)...)} : x->x) : constructor
+        _constructor = constructor === nothing ? :(u isa ModelingToolkit.StaticArrays.StaticArray ? ModelingToolkit.StaticArrays.SMatrix{$(size(rhss)...)} : default_tensor_constructor) : constructor
     elseif typeof(rhss) <: Array && !(typeof(rhss) <: Vector)
         vector_form = build_expr(:vect, [conv(rhs) for rhs ∈ rhss])
         arr_sys_expr = :(reshape($vector_form,$(size(rhss)...)))
-        _constructor = constructor === nothing ? :(u isa ModelingToolkit.StaticArrays.StaticArray ? ModelingToolkit.StaticArrays.SArray{$(size(rhss)...)} : x->x) : constructor
+        _constructor = constructor === nothing ? :(u isa ModelingToolkit.StaticArrays.StaticArray ? ModelingToolkit.StaticArrays.SArray{$(size(rhss)...)} : default_tensor_constructor) : constructor
     elseif rhss isa SparseMatrixCSC
         vector_form = build_expr(:vect, [conv(rhs) for rhs ∈ nonzeros(rhss)])
         arr_sys_expr = :(SparseMatrixCSC{eltype(u),Int}($(size(rhss)...), $(rhss.colptr), $(rhss.rowval), $vector_form))
@@ -85,15 +87,16 @@ function build_function(rhss, vs, ps = (), args = (), conv = simplified_expr, ex
 
     oop_ex = :(
         ($(fargs.args...),) -> begin
-            if $(fargs.args[1]) isa Array
+            # If u is a weird non-StaticArray type and we want a sparse matrix, just do the optimized sparse anyways
+            if $(fargs.args[1]) isa Array || (!($(fargs.args[1]) <: StaticArray) && $(rhss isa SparseMatrixCSC))
                 return $arr_bounds_block
             else
                 X = $bounds_block
+                T = promote_type(map(typeof,X)...)
+                map(T,X)
+                construct = $_constructor
+                return construct(X)
             end
-            T = promote_type(map(typeof,X)...)
-            map(T,X)
-            construct = $_constructor
-            construct(X)
         end
     )
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -88,7 +88,7 @@ function build_function(rhss, vs, ps = (), args = (), conv = simplified_expr, ex
     oop_ex = :(
         ($(fargs.args...),) -> begin
             # If u is a weird non-StaticArray type and we want a sparse matrix, just do the optimized sparse anyways
-            if $(fargs.args[1]) isa Array || (!($(fargs.args[1]) <: StaticArray) && $(rhss isa SparseMatrixCSC))
+            if $(fargs.args[1]) isa Array || (!(typeof($(fargs.args[1])) <: StaticArray) && $(rhss isa SparseMatrixCSC))
                 return $arr_bounds_block
             else
                 X = $bounds_block


### PR DESCRIPTION
The default constructor if not an array and not static array in the non-vector case is somewhat bogus, but I can't think of a good default. How do you know what "the best matrix type is" when you have an arbitrary input? I think we should just make a Matrix/SparseMatrixCSC/etc. as the default in those cases, but constructing it from the tuple is somewhat hard. I'll tackle that soon enough.